### PR TITLE
Copy n64.psh for linux

### DIFF
--- a/build_daedalus.sh
+++ b/build_daedalus.sh
@@ -87,3 +87,7 @@ case "$1" in
     echo "Building debug or profile builds requires DEBUG or PROFILE after build option"
     ;;
     esac
+    
+if [[ $1 = "LINUX" ]]; then
+    cp Source/SysGL/HLEGraphics/n64.psh LINUXbuild
+fi


### PR DESCRIPTION
When I built daedalus for Linux and tried to run it, I got this error: 

```
ERROR: couldn't load shader source /home/ian/Downloads/daedalus/LINUXbuild/n64.psh
```