### PR TITLE
Remove GH Actions depreciation warnings

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Get short SHA
       id: slug
-      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+      run: echo "{name}={sha8::$(echo ${GITHUB_SHA} | cut -c1-8)}" >> $GITHUB_OUTPUT
 
     - name: Prepare artifacts
       run: |
@@ -50,7 +50,7 @@ jobs:
     - name: Extract tag name
       if: startsWith(github.ref, 'refs/tags/')
       id: tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "{name}={VERSION::${GITHUB_REF/refs\/tags\//}}" >> $GITHUB_OUTPUT
 
     # - name: Create pre-release
     #   if: github.ref == 'refs/heads/master'
@@ -89,7 +89,7 @@ jobs:
 
     - name: Get short SHA
       id: slug
-      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+      run: echo "{name}={sha8::$(echo ${GITHUB_SHA} | cut -c1-8)}" >> $GITHUB_OUTPUT
 
     - name: Prepare artifacts
       run: |
@@ -172,7 +172,7 @@ jobs:
 
       - name: Get short SHA
         id: slug
-        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+        run: echo "{name}={sha8::$(echo ${GITHUB_SHA} | cut -c1-8)}" >> $GITHUB_OUTPUT
 
       - name: Prepare artifacts
         run: |
@@ -203,7 +203,7 @@ jobs:
 
     - name: Get short SHA
       id: slug
-      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+      run: echo "{name}={sha8::$(echo ${GITHUB_SHA} | cut -c1-8)}" >> $GITHUB_OUTPUT
 
     - name: Prepare artifacts
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,7 +13,7 @@ jobs:
     container: pspdev/pspdev:latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -42,7 +42,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: DaedalusX64-PSP
         path: daedalusX64-PSP.tar.gz
@@ -77,7 +77,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -106,7 +106,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: daedalusX64-linux
         path: daedalusX64-linux.tar.gz
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm:latest
     steps:
-      - uses: actions/checkout@v2 
+      - uses: actions/checkout@v4 
 
       # Needed to build CIA files
       - name: build makerom
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: daedalusX64-CTR
           path: daedalusX64-CTR.tar.gz
@@ -188,7 +188,7 @@ jobs:
   build-macos:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Homebrew # This will install the correct homebrew for architecture selected
       run: |
@@ -220,7 +220,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: DaedalusX64-macos
         path: daedalusX64-macos-x86.tar.gz
@@ -255,7 +255,7 @@ jobs:
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: lukka/get-cmake@latest
 


### PR DESCRIPTION
Updated Actions/Artifacts also supplied new syntax for set-output (soon to be deprecated)


Before
![image](https://github.com/DaedalusX64/daedalus/assets/39999447/710ee721-84bb-4890-8ef0-9fe1aac3fd89)



After 
![image](https://github.com/DaedalusX64/daedalus/assets/39999447/a2c8f021-cb89-4b51-a00c-595077ce81e2)
 