### PR TITLE
Use __builtin_trap on PSP to generate a breakpoint

### DIFF
--- a/Source/Base/Assert.h
+++ b/Source/Base/Assert.h
@@ -37,9 +37,7 @@ enum EAssertResult
 	AR_BREAK,
 };
 
-#ifdef DAEDALUS_PSP
-    #define DAEDALUS_HALT			__asm__ __volatile__ ( "break" )
-#elif DAEDALUS_POSIX
+#if defined(DAEDALUS_PSP) || defined(DAEDALUS_POSIX)
     #define DAEDALUS_HALT			__builtin_trap()
 #elif DAEDALUS_CTR
     #define DAEDALUS_HALT			__asm__ __volatile__ ( "bkpt" )


### PR DESCRIPTION
Current toolchains do emit a break on __builtin_trap already.