### PR TITLE
WIP: me-core-mapper library integration

### DIFF
--- a/Source/HLEAudio/Plugin/PSP/AudioPluginPSP.cpp
+++ b/Source/HLEAudio/Plugin/PSP/AudioPluginPSP.cpp
@@ -51,24 +51,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #ifdef DAEDALUS_PSP_USE_ME
 
-#include "SysPSP/PRX/MediaEngine/me.h"
+#include <me-core-mapper/me-core.h>
 #include "SysPSP/Utility/ModulePSP.h"
 
 bool gLoadedMediaEnginePRX {false};
-
-volatile me_struct *mei;
 
 bool InitialiseMediaEngine()
 {
 	if ( gLoadedMediaEnginePRX == false)
 	{
-		if( CModule::Load("Plugins/mediaengine.prx") < 0 )	return false;
-
-		mei = (volatile struct me_struct *)malloc_64(sizeof(struct me_struct));
-		mei = (volatile struct me_struct *)(make_uncached_ptr(mei));
-		sceKernelDcacheWritebackInvalidateAll();
-
-		if (InitME(mei) == 0)
+		if (meLibDefaultInit() >= 0)
 		{
 			gLoadedMediaEnginePRX = true;
 			return true;
@@ -228,6 +220,11 @@ void	AudioPluginPSP::LenChanged()
 	}
 }
 
+#ifdef DAEDALUS_PSP_USE_ME
+void meLibOnProcess() {
+  // todo
+}
+#endif  
 
 EProcessResult	AudioPluginPSP::ProcessAList()
 {
@@ -243,12 +240,16 @@ EProcessResult	AudioPluginPSP::ProcessAList()
 		case APM_ENABLED_ASYNC:
 			{
 #ifdef DAEDALUS_PSP_USE_ME
-				sceKernelDcacheWritebackInvalidateAll();
+        // todo: process to be defined, to be used with meLibOnProcess
+
+				/*
+         * sceKernelDcacheWritebackInvalidateAll();
 				if(BeginME( mei, (int)&Audio_Ucode, (int)NULL, -1, NULL, -1, NULL) < 0){
 						Audio_Ucode();
 						result = PR_COMPLETED;
 						break;
 				}
+        */
 #else
 				DAEDALUS_ERROR("Async audio is unimplemented");
 				Audio_Ucode();

--- a/Source/SysPSP/CMakeLists.txt
+++ b/Source/SysPSP/CMakeLists.txt
@@ -19,7 +19,7 @@ set(daed_libs ${daed_libs} PARENT_SCOPE)
 if(DAEDALUS_SDL)
 list(APPEND sys_libraries pspkubridge pspfpu pspdebug SDL2_ttf freetype harfbuzz bz2)
 else()
-list(APPEND sys_libraries intrafont pspkubridge pspfpu pspdebug pspgu pspge pspaudio pspaudiolib psppower pspctrl pspdisplay)
+list(APPEND sys_libraries me-core intrafont pspkubridge pspfpu pspdebug pspgu pspge pspaudio pspaudiolib psppower pspctrl pspdisplay)
 endif()
  set(sys_libraries ${sys_libraries} PARENT_SCOPE)
 


### PR DESCRIPTION
- Add basic setup and initialization of me-core-mapper as the new Media Engine library
Note: Needs a new temporary/experimental branch to ease work sharing while attempting to switch to me-core-mapper as the ME library